### PR TITLE
fix: Remove vulnerable Log4j 1.2.17 dependency (CVE)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,6 @@
         <jboss-servlet-api_4.0_spec>2.0.0.Final</jboss-servlet-api_4.0_spec>
         <jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec.version>2.0.1.Final</jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec.version>
         <jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.3_spec.version>2.0.0.Final</jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.3_spec.version>
-        <log4j.version>1.2.17</log4j.version>
         <log4j2-api.version>2.24.3</log4j2-api.version> <!-- Odd name needs to align with Quarkus -->
         <resteasy.version>6.2.12.Final</resteasy.version>
         <resteasy.undertow.version>${resteasy.version}</resteasy.undertow.version>
@@ -534,11 +533,6 @@
                 <artifactId>picketlink-wildfly-common</artifactId>
                 <version>${picketlink.version}</version>
                 <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>log4j</groupId>
-                <artifactId>log4j</artifactId>
-                <version>${log4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>

--- a/testsuite/integration-arquillian/tests/pom.xml
+++ b/testsuite/integration-arquillian/tests/pom.xml
@@ -397,7 +397,7 @@
                         <systemPropertyVariables>
                             <project.build.directory>${project.build.directory}</project.build.directory>
                             <arquillian.xml>${project.build.directory}/dependency/arquillian.xml</arquillian.xml>
-                            <log4j.configuration>file:${project.build.directory}/dependency/log4j.properties</log4j.configuration> <!-- for the logging to properly work with tests in the 'other' module -->
+                            <log4j.configuration>file:${project.build.directory}/dependency/log4j2.xml</log4j.configuration> <!-- for the logging to properly work with tests in the 'other' module -->
 
                             <auth.server>${auth.server}</auth.server>
                             <auth.server.container>${auth.server.container}</auth.server.container>
@@ -1571,16 +1571,21 @@
                 </dependency>-->
 
                 <dependency>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-api</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-core</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j2-impl</artifactId>
+                    <version>${log4j2-api.version}</version>
                 </dependency>
                 <dependency>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-reload4j</artifactId>
                 </dependency>
 
                 <dependency>

--- a/testsuite/model/pom.xml
+++ b/testsuite/model/pom.xml
@@ -23,7 +23,7 @@
         <jdbc.mvn.groupId>com.h2database</jdbc.mvn.groupId>
         <jdbc.mvn.artifactId>h2</jdbc.mvn.artifactId>
         <jdbc.mvn.version>${h2.version}</jdbc.mvn.version>
-        <log4j.configuration>file:${project.build.directory}/dependency/log4j.properties</log4j.configuration>
+        <log4j.configuration>file:${project.build.directory}/dependency/log4j2.xml</log4j.configuration>
         <jacoco.skip>true</jacoco.skip>
     </properties>
     
@@ -45,16 +45,21 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <version>${log4j2-api.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-reload4j</artifactId>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
@@ -172,9 +177,9 @@
                         <keycloak.connectionsJpa.default.user>${keycloak.connectionsJpa.user}</keycloak.connectionsJpa.default.user>
                         <keycloak.connectionsJpa.default.password>${keycloak.connectionsJpa.password}</keycloak.connectionsJpa.default.password>
                         <keycloak.connectionsJpa.default.url>${keycloak.connectionsJpa.url}</keycloak.connectionsJpa.default.url>
-                        <log4j.configuration>file:${project.build.directory}/test-classes/log4j.properties</log4j.configuration> <!-- for the logging to properly work with tests in the 'other' module -->
+                        <log4j.configuration>file:${project.build.directory}/test-classes/log4j2.xml</log4j.configuration> <!-- for the logging to properly work with tests in the 'other' module -->
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                        <org.jboss.logging.provider>log4j</org.jboss.logging.provider>
+                        <org.jboss.logging.provider>log4j2</org.jboss.logging.provider>
                         <infinispan.version>${infinispan.version}</infinispan.version>
                         <project.version>${project.version}</project.version>
                     </systemPropertyVariables>

--- a/testsuite/utils/pom.xml
+++ b/testsuite/utils/pom.xml
@@ -78,13 +78,19 @@
             <artifactId>keycloak-account-ui</artifactId>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-reload4j</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <version>${log4j2-api.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/util/embedded-ldap/pom.xml
+++ b/util/embedded-ldap/pom.xml
@@ -52,18 +52,24 @@
             <artifactId>jboss-logging</artifactId>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <version>${log4j2-api.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-reload4j</artifactId>
-            <scope>compile</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Description
This PR addresses a security vulnerability in Log4j 1.2.x where the SocketServer class is vulnerable to deserialization of untrusted data. This vulnerability can be exploited to remotely execute arbitrary code when combined with a deserialization gadget when listening to untrusted network traffic for log data.

### Changes
- Removed Log4j 1.2.17 from root `pom.xml`
- Migrated all modules to Log4j 2.24.3:
  - testsuite/model
  - testsuite/utils
  - testsuite/integration-arquillian/tests
  - util/embedded-ldap
- Replaced `slf4j-reload4j` with `log4j-slf4j2-impl`
- Updated logging configuration from `log4j.properties` to `log4j2.xml`
- Updated `org.jboss.logging.provider` to use `log4j2`

### Security Impact
This change mitigates a deserialization vulnerability that affects Log4j versions 1.2 up to 1.2.17. The vulnerability has no CVE assigned but was reported in Log4j's issue tracker.

### Migration Notes
The change moves from Log4j 1.x to Log4j 2.x which is the recommended logging framework. Log4j 2 provides significant improvements in terms of performance, security, and features over Log4j 1.x.

### Testing Done
- [ ] Verify all tests pass with new logging implementation
- [ ] Verify logging works correctly across all affected modules
- [ ] Verify no regression in functionality

### Related Issues
Fixes #11

### Documentation Impact
No documentation changes required as this is an internal dependency update.